### PR TITLE
Database seeding and Separate Databases for Prod and Testing

### DIFF
--- a/TestWaitForIt/App.config
+++ b/TestWaitForIt/App.config
@@ -4,6 +4,10 @@
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
+  <connectionStrings>
+    <add name="TestDB" connectionString="Server=.\SQLExpress;Database=TestDB;Trusted_Connection=true;" providerName="System.Data.SqlClient"/>
+    <!-- add name="ProdDB" connectionString="Server=.\SQLExpress;DatabaseName=WaitForIt.EventContext;Trusted_Connection=true"/ -->
+  </connectionStrings>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
     <providers>

--- a/TestWaitForIt/EventRepositoryTest.cs
+++ b/TestWaitForIt/EventRepositoryTest.cs
@@ -19,7 +19,9 @@ namespace TestWaitForIt
         [ClassInitialize]
         public static void SetUp(TestContext _context)
         {
-            repo = new EventRepository();
+            // Pass the name of the connection string TAG not the
+            // name of the database you want to use
+            repo = new EventRepository("Name=TestDB");
             repo.Clear();
         }
 

--- a/WaitForIt/EventContext.cs
+++ b/WaitForIt/EventContext.cs
@@ -10,6 +10,7 @@ namespace WaitForIt
 {
     public class EventContext: DbContext
     {
+
         public DbSet<Event> Events { get; set; }
     }
 }

--- a/WaitForIt/EventContext.cs
+++ b/WaitForIt/EventContext.cs
@@ -10,7 +10,10 @@ namespace WaitForIt
 {
     public class EventContext: DbContext
     {
+        public EventContext(string connection="WaitForIt.EventContext") : base(connection)
+        {
 
+        }
         public DbSet<Event> Events { get; set; }
     }
 }

--- a/WaitForIt/Migrations/201502111736176_AddHashField.cs
+++ b/WaitForIt/Migrations/201502111736176_AddHashField.cs
@@ -8,6 +8,9 @@ namespace WaitForIt.Migrations
         public override void Up()
         {
             AddColumn("dbo.Events", "Hash", x => x.String());
+            
+            // How to give a field the NOT NULL constraint and provide default values
+            //AddColumn("dbo.Events", "Hash", x => x.String(nullable: false, defaultValue: "xxxxxxxxx"));
         }
         
         public override void Down()

--- a/WaitForIt/Migrations/Configuration.cs
+++ b/WaitForIt/Migrations/Configuration.cs
@@ -16,7 +16,10 @@ namespace WaitForIt.Migrations
         protected override void Seed(WaitForIt.EventContext context)
         {
             //  This method will be called after migrating to the latest version.
-
+            context.Events.AddOrUpdate<Model.Event>(
+                n => n.Name, // ANY LINQ expression
+                new Model.Event { Name = "Jurnell's Birthday", Date = "10/05/2015"}
+             );
             //  You can use the DbSet<T>.AddOrUpdate() helper extension method 
             //  to avoid creating duplicate seed data. E.g.
             //

--- a/WaitForIt/Migrations/Configuration.cs
+++ b/WaitForIt/Migrations/Configuration.cs
@@ -9,7 +9,7 @@ namespace WaitForIt.Migrations
     {
         public Configuration()
         {
-            AutomaticMigrationsEnabled = false;
+            AutomaticMigrationsEnabled = true;
             ContextKey = "WaitForIt.EventContext";
         }
 

--- a/WaitForIt/Repository/EventRepository.cs
+++ b/WaitForIt/Repository/EventRepository.cs
@@ -13,9 +13,9 @@ namespace WaitForIt.Repository
     {
         private EventContext _dbContext;
 
-        public EventRepository()
+        public EventRepository(string connection = "WaitForIt.EventContext")
         {
-            _dbContext = new EventContext();
+            _dbContext = new EventContext(connection);
             _dbContext.Events.Load();
         }
 
@@ -93,6 +93,8 @@ namespace WaitForIt.Repository
 
         public IEnumerable<Model.Event> All()
         {
+            // First look to see if the stash is populated. If so
+            // then return that stash otherwise do what's below.
             var qu = from Event in _dbContext.Events select Event;
             return qu.ToList<Model.Event>();
         }


### PR DESCRIPTION
The PR contains the following:
- Uses Configuration.cs for seedint the prod database and auto run migrations.
- TestWaitForIt/App.config contains connection string for Test DB usage
- modified EventRepository and EventContext to optionally allow for custom connection strings
- Have the Repository tests use only the testDB.

@elizabrock 
